### PR TITLE
Sort languages options in select

### DIFF
--- a/src/codeflask.js
+++ b/src/codeflask.js
@@ -195,18 +195,17 @@
     for (var i = 0; i < Object.keys(Prism.languages).length; i++) {
 
         // Weirdly PrismJS doesnt expose a list of installed languages, or rather it does, but it is mixed with helper functions, which i have to clear here.
-        if( !(Object.keys(Prism.languages)[i] == "extend") && !(Object.keys(Prism.languages)[i] == "insertBefore") && !(Object.keys(Prism.languages)[i] == "DFS")){
-
-          var option = document.createElement("option");
-          option.value = Object.keys(Prism.languages)[i];
-          option.text = Object.keys(Prism.languages)[i];
-          if(Object.keys(Prism.languages)[i] == this.data.language){
-            option.selected="selected"
-          }
-          languagesSelect.appendChild(option);
-
+        if (Object.keys(Prism.languages)[i] == "extend" || Object.keys(Prism.languages)[i] == "insertBefore" || Object.keys(Prism.languages)[i] == "DFS") {
+          continue;
         }
 
+        var option = document.createElement("option");
+        option.value = Object.keys(Prism.languages)[i];
+        option.text = Object.keys(Prism.languages)[i];
+        if(Object.keys(Prism.languages)[i] == this.data.language){
+          option.selected="selected"
+        }
+        languagesSelect.appendChild(option);
     }
 
     languagesSelect.addEventListener('change', (event) => {

--- a/src/codeflask.js
+++ b/src/codeflask.js
@@ -189,20 +189,23 @@
 
     let languagesSelect = document.createElement("select");
     languagesSelect.classList.add("small");
-    // languagesSelect.id = "mySelect";
+
+    //sort available languages alphabetically (ignore case)
+    let languages = Object.keys(Prism.languages).sort(function (a, b) {
+        return a.toLowerCase().localeCompare(b.toLowerCase());
+    });
 
     //Create and append the options
-    for (var i = 0; i < Object.keys(Prism.languages).length; i++) {
-
+    for (var i = 0; i < languages.length; i++) {
         // Weirdly PrismJS doesnt expose a list of installed languages, or rather it does, but it is mixed with helper functions, which i have to clear here.
-        if (Object.keys(Prism.languages)[i] == "extend" || Object.keys(Prism.languages)[i] == "insertBefore" || Object.keys(Prism.languages)[i] == "DFS") {
+        if (languages[i] == "extend" || languages[i] == "insertBefore" || languages[i] == "DFS") {
           continue;
         }
 
         var option = document.createElement("option");
-        option.value = Object.keys(Prism.languages)[i];
-        option.text = Object.keys(Prism.languages)[i];
-        if(Object.keys(Prism.languages)[i] == this.data.language){
+        option.value = languages[i];
+        option.text = languages[i];
+        if(languages[i] == this.data.language){
           option.selected="selected"
         }
         languagesSelect.appendChild(option);


### PR DESCRIPTION
It looks quite unpleasant with languages on the select list being in mostly random order, so this PR is to have them sorted alphabetically (case insensitive).